### PR TITLE
Update dbreader.py

### DIFF
--- a/dbreader.py
+++ b/dbreader.py
@@ -3,7 +3,7 @@ import numpy as np
 import cPickle as pickle
 
 print('reading...')
-db = pickle.load(open("dev_letter_D.p","rb"))
+db = pickle.load(open("dev_letter_D.p","rb"),encoding = "ISO-8859-1")
 
 print("Number of letter images in the dataset are:" + str(len(db)))
 


### PR DESCRIPTION
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd3 in position 0: ordinal not in range(128)
To solve the above error, mention correct encoding to pickle.load